### PR TITLE
Fix grep command to exclude group separators

### DIFF
--- a/src/functions.c
+++ b/src/functions.c
@@ -195,7 +195,7 @@ Boolean exist_file(char *path) {
 
 Boolean find_kbdevent_info(KBDDEVINFO *devs, int* devcnt, int maxdevs) {
 	char cmd[] = GREP_CMD " -E 'Name=|Handlers|EV=' /proc/bus/input/devices | "\
-		GREP_CMD " -B2 'EV=1[02]001[3Ff]'";
+		GREP_CMD " -B2 -- 'EV=1[02]001[3Ff]' | " GREP_CMD " -v '^--$'";
 
 	char buff1[BUFSIZE+1] = {};
 	char buff2[BUFSIZE+1] = {};


### PR DESCRIPTION
Your implementation doesn't find some input devices.

In my environment, `grep -E 'Name=|Handlers|EV=' /proc/bus/input/devices` outputs:
```
B: EV=3
N: Name="Topre Corporation RealForce Compact"
H: Handlers=sysrq kbd event2 leds 
B: EV=120013
N: Name="Logitech MX Master"
H: Handlers=sysrq kbd mouse0 event5 leds 
B: EV=12001f
N: Name="HD-Audio Generic Front Mic"
H: Handlers=event6 
B: EV=21
N: Name="HD-Audio Generic Rear Mic"
H: Handlers=event7 
B: EV=21
N: Name="HD-Audio Generic Line"
H: Handlers=event8 
B: EV=21
N: Name="HD-Audio Generic Line Out Front"
H: Handlers=event9 
B: EV=21
N: Name="HD-Audio Generic Line Out Surround"
H: Handlers=event10 
B: EV=21
N: Name="HD-Audio Generic Line Out CLFE"
H: Handlers=event11 
B: EV=21
N: Name="HD-Audio Generic Front Headphone"
H: Handlers=event12 
B: EV=21
N: Name="Eee PC WMI hotkeys"
H: Handlers=rfkill kbd event13 
B: EV=100013
N: Name="HDA NVidia HDMI/DP,pcm=3"
H: Handlers=event14 
B: EV=21
N: Name="HDA NVidia HDMI/DP,pcm=7"
H: Handlers=event15 
B: EV=21
N: Name="HDA NVidia HDMI/DP,pcm=8"
H: Handlers=event16 
B: EV=21
N: Name="SIGMACHIP USB Keyboard"
H: Handlers=sysrq kbd event3 leds 
B: EV=120013
N: Name="SIGMACHIP USB Keyboard"
H: Handlers=kbd event4 
B: EV=1f
```
and `grep -E 'Name=|Handlers|EV=' /proc/bus/input/devices | grep -B2 -- 'EV=1[02]001[3Ff]'` outputs:
```
N: Name="Topre Corporation RealForce Compact"
H: Handlers=sysrq kbd event2 leds 
B: EV=120013
N: Name="Logitech MX Master"
H: Handlers=sysrq kbd mouse0 event5 leds 
B: EV=12001f
--
N: Name="Eee PC WMI hotkeys"
H: Handlers=rfkill kbd event13 
B: EV=100013
--
N: Name="SIGMACHIP USB Keyboard"
H: Handlers=sysrq kbd event3 leds 
B: EV=120013
```
including unnecessary `--`s.

This can be avoided by my solution. You can use `--no-group-separator` option as well, but this doesn't work for BSD grep.