### PR TITLE
Add configuration item to set keyboard name.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -326,7 +326,10 @@ Boolean load_config(char* path)
 				set_inputdevice_path(devpath);
 			}
 		} else */
-		if (strcasecmp(key, "LOYAKEY")==0) {
+		if (strcasecmp(key, "KEYBOARDNAME")==0) {
+			printf("KEYBOARDNAME: %s\n", value);
+			set_keyboardname(value);
+		} else if (strcasecmp(key, "LOYAKEY")==0) {
 			kc = keyname_to_code(value);
 			if (kc != 0) {
 				printf("LOYAKEY: %s\n", value);
@@ -399,6 +402,9 @@ Boolean save_config(char *path)
 	if ((fp = fopen(path, "w")) == NULL) {
 		return FALSE;
 	}
+	fprintf(fp, "# キーボード名\n");
+	fprintf(fp, "#KEYBOARDNAME=XXXX\n");
+	fprintf(fp, "\n");
 	fprintf(fp, "# 左親指キー　(スペースキー＝SPACE, 無変換キー＝MUHENKAN)\n");
 	fprintf(fp, "LOYAKEY=SPACE\n");
 	fprintf(fp, "\n");

--- a/src/oyainput.h
+++ b/src/oyainput.h
@@ -3,6 +3,8 @@
  */
 
 int get_kbdevie_output();
+void set_keyboardname(char* value);
+const char* get_keyboardname();
 void set_imtype(char* imname);
 int get_imtype();
 void set_inputdevice_path(char * new_devpath);


### PR DESCRIPTION
On my PC, multiple keyboard is detected but I'm using only 1 keyboard:
```
multiple keyboard is detected.
0: Eee PC WMI hotkeys  # <---- I'm not connecting this device
1: Topre Corporation RealForce Compact
```

(This is not an issue of oyainput. The 'Eee PC WMI hotkeys' actually exists in /proc/bus/input/devices. Hmm, what is this... )

So, I want oyainput to determine which keyboard should be used by configuration for autostarting.
This is because I wrote this patch.

Thank you.